### PR TITLE
Remove `DownValues` hack for Mathics/WMA return value compatibility.

### DIFF
--- a/IntegrationUtilityFunctions.m
+++ b/IntegrationUtilityFunctions.m
@@ -7734,11 +7734,8 @@ RuleName[name_] :=
 
 ClearAll[FixIntRules,FixIntRule,FixRhsIntRule]
 
-dvMathicsToMath = RuleDelayed[Verbatim[HoldPattern][Verbatim[Condition][lhs_,cond_]],rhs_] :> RuleDelayed[HoldPattern[lhs],Condition[rhs,cond]];
-dvMathToMathics = RuleDelayed[Verbatim[HoldPattern][lhs_], Verbatim[Condition][rhs_,cond_]] :> RuleDelayed[HoldPattern[Condition[lhs,cond]],rhs];
-
 FixIntRules[] :=
-  (DownValues[Int]=FixIntRules[DownValues[Int] /. dvMathicsToMath] /. dvMathToMathics; Null)
+  (DownValues[Int]=FixIntRules[DownValues[Int]]; Null)
 
 
 FixIntRules[rulelist_] := Block[{Int, Subst, Simp, Star},

--- a/IntegrationUtilityFunctions.m
+++ b/IntegrationUtilityFunctions.m
@@ -4103,13 +4103,13 @@ Star::usage = "Star[u,v] displays as u*v, and returns the product of u and v wit
 
 DownValues[Star]={};
 
-
+(*
 Star::error = "Inert multiplication by zero!";
 Star[u_,v_] := (
   Message[Star::error];
   0 ) /; 
 EqQ[u,0]
-
+*)
 
 Star[u_,v_] := 
   Map[Function[Star[u,#]],v] /; 

--- a/IntegrationUtilityFunctions.m
+++ b/IntegrationUtilityFunctions.m
@@ -363,12 +363,12 @@ IntegralFreeQ[u_] :=
 
 EqQ::usage = "If u-v equals 0, EqQ[u,v] returns True; else it returns False.";
 EqQ[u_,v_] := Quiet[PossibleZeroQ[u-v]] || Refine[u==v]===True
-EqQ[args___] := Null /; CheckArguments[EqQ[args], 2]
+EqQ[args___] := Null (*/; CheckArguments[EqQ[args], 2]*)
 
 
 NeQ::usage = "If u-v equals 0, NeQ[u,v] returns False; else it returns True.";
 NeQ[u_,v_] := Not[Quiet[PossibleZeroQ[u-v]] || Refine[u==v]===True]
-NeQ[args___] := Null /; CheckArguments[NeQ[args], 2]
+NeQ[args___] := Null (*/; CheckArguments[NeQ[args], 2]*)
 
 
 (* ::Subsection::Closed:: *)
@@ -377,22 +377,22 @@ NeQ[args___] := Null /; CheckArguments[NeQ[args], 2]
 
 IGtQ::usage = "n must be a rational number.  If u is an integer and u>n, IGtQ[u,n] returns True; else it returns False.";
 IGtQ[u_,n_] := IntegerQ[u] && u>n
-IGtQ[args___] := Null /; CheckArguments[IGtQ[args], 2]
+IGtQ[args___] := Null (*/; CheckArguments[IGtQ[args], 2]*)
 
 
 ILtQ::usage = "n must be a rational number.  If u is an integer and u<n, ILtQ[u,n] returns True; else it returns False.";
 ILtQ[u_,n_] := IntegerQ[u] && u<n
-ILtQ[args___] := Null /; CheckArguments[ILtQ[args], 2]
+ILtQ[args___] := Null (*/; CheckArguments[ILtQ[args], 2]*)
 
 
 IGeQ::usage = "n must be a rational number.  If u is an integer and u>=n, IGeQ[u,n] returns True; else it returns False.";
 IGeQ[u_,n_] := IntegerQ[u] && u>=n
-IGeQ[args___] := Null /; CheckArguments[IGeQ[args], 2]
+IGeQ[args___] := Null (*/; CheckArguments[IGeQ[args], 2]*)
 
 
 ILeQ::usage = "n must be a rational number.  If u is an integer and u<=n, ILeQ[u,n] returns True; else it returns False.";
 ILeQ[u_,n_] := IntegerQ[u] && u<=n
-ILeQ[args___] := Null /; CheckArguments[ILeQ[args], 2]
+ILeQ[args___] := Null (*/; CheckArguments[ILeQ[args], 2]*)
 
 
 (* ::Subsection::Closed:: *)

--- a/Rubi.m
+++ b/Rubi.m
@@ -217,11 +217,6 @@ TraceBuiltins[dvFixWithNoCond = RuleDelayed[Verbatim[HoldPattern][lhs_],With[var
 TraceBuiltins[DownValues[Int] = DownValues[Int] /. dvFixWith /. dvFixWithNoCond, SortBy->"count"];
 Print[""];
 
-(* Dummy CheckArguments *)
-CheckArguments[a_, n_] := n == 1;
-CheckArguments[f_[args___], n_] := Length[{args}] == n;
-SetAttributes[CheckArguments, HoldFirst];
-
 If[$LoadShowSteps === True,
   StatusBarPrint["Modifying " <> ToString[$RuleCount] <> " integration rules to display steps..."];
   StepFunction[Int];

--- a/Rubi.m
+++ b/Rubi.m
@@ -220,6 +220,7 @@ Print[""];
 (* Dummy CheckArguments *)
 CheckArguments[a_, n_] := n == 1;
 CheckArguments[f_[args___], n_] := Length[{args}] == n;
+SetAttributes[CheckArguments, HoldFirst];
 
 If[$LoadShowSteps === True,
   StatusBarPrint["Modifying " <> ToString[$RuleCount] <> " integration rules to display steps..."];

--- a/Rubi.m
+++ b/Rubi.m
@@ -217,6 +217,10 @@ TraceBuiltins[dvFixWithNoCond = RuleDelayed[Verbatim[HoldPattern][lhs_],With[var
 TraceBuiltins[DownValues[Int] = DownValues[Int] /. dvFixWith /. dvFixWithNoCond, SortBy->"count"];
 Print[""];
 
+(* Dummy CheckArguments *)
+CheckArguments[a_, n_] := n == 1;
+CheckArguments[f_[args___], n_] := Length[{args}] == n;
+
 If[$LoadShowSteps === True,
   StatusBarPrint["Modifying " <> ToString[$RuleCount] <> " integration rules to display steps..."];
   StepFunction[Int];

--- a/Test.m
+++ b/Test.m
@@ -37,7 +37,7 @@ ExpressionType::usage = "ExpressionType[expn,var] returns expn's type number bas
 (* ::Section::Closed:: *)
 (*Mathematica Test Functions*)
 
-If[Not[ValueQ[$ItegrationTestProgramDir], $IntegrationTestProgramDir = Directory[]]];
+If[Not[ValueQ[$ItegrationTestProgramDir]], $IntegrationTestProgramDir = Directory[]];
 
 Begin["`Private`"];
 


### PR DESCRIPTION
Mathics and WMA return values for `DownValues` are now compatible, see https://github.com/Mathics3/mathics-core/issues/1209. This PR remove a hack that converted Mathics output to WMA and back.